### PR TITLE
fix bug: fetch第三方数据时发送整个json对象的post请求

### DIFF
--- a/sumeru/src/controller.js
+++ b/sumeru/src/controller.js
@@ -215,7 +215,7 @@ var runnable = function(fw){
         redirect:function(queryPath,paramMap,isforce){
             var urlHash = queryPath;
             if(paramMap){
-                urlHash += "!" + fw.utils.mapToUriParam(paramMap);
+                urlHash += "?" + fw.utils.mapToUriParam(paramMap);
             }
             fw.router.redirect(urlHash,isforce);
         },

--- a/sumeru/src/external.js
+++ b/sumeru/src/external.js
@@ -672,15 +672,27 @@ var runnable = function(fw, findDiff, publishBaseDir, externalConfig, http, serv
 	 */
 	function sendPostRequest(options, postData, cb){
 		//server
+		var defaultOptions;
 		if(fw.IS_SUMERU_SERVER){
-            postData = encodeURIComponent(JSON.stringify(postData));
-            var defaultOptions = {
-				method : 'POST',
-				headers: {
-			        'Content-Type': 'application/x-www-form-urlencoded',
-			        'Content-Length': postData.length
+			if (options && options.json === true) {
+        postData = JSON.stringify(postData);
+        defaultOptions = {
+					method : 'POST',
+					headers: {
+		        'Content-Type': 'application/json',
+		        'Content-Length': postData.length
 			    }
-			};
+				};
+			} else {
+        postData = encodeURIComponent(JSON.stringify(postData));
+        defaultOptions = {
+					method : 'POST',
+					headers: {
+		        'Content-Type': 'application/x-www-form-urlencoded',
+		        'Content-Length': postData.length
+			    }
+				};
+			}
 
 			var opts = Library.objUtils.extend(true, defaultOptions, options);
 


### PR DESCRIPTION
当post请求的body一个json对象时，Content-type应为application/json，且不对body进行encodeURIComponent。

commit c33cdeb 可供参考 。添加了options参数json，为true时使用上述的解决方案，否则默认使用原来的方法。
